### PR TITLE
Get rid of click

### DIFF
--- a/hecker/__init__.py
+++ b/hecker/__init__.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: GPL-2.0
 
-import click
+import sys
 
 
-@click.command("hecker")
-@click.argument("text", type=str)
-def main(text: str) -> None:
-    click.echo(f"*in hacker voice*: {text}")
+def main() -> None:
+    args_count = len(sys.argv)
+    if args_count != 2:
+        print("Usage: hecker TEXT")
+        sys.exit(1)
+
+    print(f"*in hacker voice*: {sys.argv[1]}")
 
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hecker
-version = 0.1.0
+version = 0.2.0
 url = https://github.com/packit/redhat-internal-test-package
 description = Traslator which translates your text to hacker text.
 long_description = file: README.md
@@ -22,7 +22,6 @@ classifiers =
 
 [options]
 packages = find:
-install_requires = click
 python_requires = >=3.7
 include_package_data = True
 


### PR DESCRIPTION
It's not possible to upload a package with epel dependency to centos stream's dist-git. In this case `click` is only available in epel thus it's not possible to require this dependency (the build tests in centos stream's dist-git will fail)